### PR TITLE
Updates for Paola's new database format

### DIFF
--- a/ARCCSSive/CMIP5/DB.py
+++ b/ARCCSSive/CMIP5/DB.py
@@ -24,7 +24,7 @@ import os
 from sqlalchemy import create_engine, func, select, join, and_
 from sqlalchemy.orm import sessionmaker
 
-from ARCCSSive.CMIP5.Model import Base, Version, Variable
+from ARCCSSive.CMIP5.Model import Base, Version, Instance
 
 SQASession = sessionmaker()
 
@@ -48,7 +48,7 @@ class Session():
 
         Returns a list of files that match the arguments
 
-        :argument **kwargs: Match any attribute in :class:`Model.Variable`, e.g. `model = 'ACCESS1-3'`
+        :argument **kwargs: Match any attribute in :class:`Model.Instance`, e.g. `model = 'ACCESS1-3'`
 
         :return: An iterable returning :py:class:`Model.File`
             matching the search query
@@ -60,43 +60,43 @@ class Session():
 
         :return: A list of strings
         """
-        return [x[0] for x in self.query(Variable.model).distinct().all()]
+        return [x[0] for x in self.query(Instance.model).distinct().all()]
 
     def experiments(self):
         """ Get the list of all experiments in the dataset
 
         :return: A list of strings
         """
-        return [x[0] for x in self.query(Variable.experiment).distinct().all()]
+        return [x[0] for x in self.query(Instance.experiment).distinct().all()]
 
     def variables(self):
         """ Get the list of all variables in the dataset
 
         :return: A list of strings
         """
-        return [x[0] for x in self.query(Variable.variable).distinct().all()]
+        return [x[0] for x in self.query(Instance.variable).distinct().all()]
 
     def mips(self):
         """ Get the list of all MIP tables in the dataset
 
         :return: A list of strings
         """
-        return [x[0] for x in self.query(Variable.mip).distinct().all()]
+        return [x[0] for x in self.query(Instance.mip).distinct().all()]
 
     def outputs(self, **kwargs):
         """ Get the most recent files matching a query
 
         Arguments are optional, using them will select only matching outputs
 
-        :argument variable: Variable name
+        :argument variable: Instance name
         :argument experiment: CMIP experiment
         :argument mip: MIP table
         :argument model: Model used to generate the dataset
         :argument ensemble: Ensemble member
 
-        :return: An iterable sequence of :class:`ARCCSSive.CMIP5.Model.Variable`
+        :return: An iterable sequence of :class:`ARCCSSive.CMIP5.Model.Instance`
         """
-        return self.query(Variable).filter_by(**kwargs)
+        return self.query(Instance).filter_by(**kwargs)
 
 
 def connect(path = None):

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ ARCCSS Data Access Tools
 [![Documentation Status](https://readthedocs.org/projects/arccssive/badge/?version=latest)](https://readthedocs.org/projects/arccssive/?badge=latest)
 [![Build Status](https://travis-ci.org/coecms/ARCCSSive.svg?branch=master)](https://travis-ci.org/coecms/ARCCSSive)
 [![codecov.io](http://codecov.io/github/coecms/ARCCSSive/coverage.svg?branch=master)](http://codecov.io/github/coecms/ARCCSSive?branch=master)
+[![Code Health](https://landscape.io/github/coecms/ARCCSSive/master/landscape.svg?style=flat)](https://landscape.io/github/coecms/ARCCSSive/master)
 [![Code Climate](https://codeclimate.com/github/coecms/ARCCSSive/badges/gpa.svg)](https://codeclimate.com/github/coecms/ARCCSSive)
 [![PyPI version](https://badge.fury.io/py/ARCCSSive.svg)](https://pypi.python.org/pypi/ARCCSSive)
 

--- a/tests/CMIP5/db_fixture.py
+++ b/tests/CMIP5/db_fixture.py
@@ -32,6 +32,7 @@ def insert_unique(db, klass, **kwargs):
     except NoResultFound:
         value = klass(**kwargs)
         db.add(value)
+        db.commit()
     return value
 
 def add_item(db, variable, mip, model, experiment, ensemble, path, version):

--- a/tests/CMIP5/db_fixture.py
+++ b/tests/CMIP5/db_fixture.py
@@ -20,8 +20,35 @@ limitations under the License.
 
 import pytest
 from ARCCSSive import CMIP5
-from ARCCSSive.CMIP5.DB import update
-from ARCCSSive.CMIP5.Model import Latest
+from ARCCSSive.CMIP5.Model import *
+from sqlalchemy.orm.exc import NoResultFound
+
+def insert_unique(db, klass, **kwargs):
+    """
+    Insert an item into the DB if it can't be found
+    """
+    try:
+        value = db.query(klass).filter_by(**kwargs).one()
+    except NoResultFound:
+        value = klass(**kwargs)
+        db.add(value)
+    return value
+
+def add_item(db, variable, mip, model, experiment, ensemble, path, version):
+    """
+    Add a new test item to the DB
+    """
+    instance = insert_unique(db, Instance,
+            variable   = variable,
+            mip        = mip,
+            model      = model,
+            experiment = experiment,
+            ensemble   = ensemble)
+
+    version = insert_unique(db, Version,
+            instance_id = instance.id,
+            path        = path,
+            version     = version)
 
 @pytest.fixture(scope="module")
 def session(request, tmpdir_factory):
@@ -32,34 +59,31 @@ def session(request, tmpdir_factory):
 
     # Create some example entries
     db = session.session
-    db.add(Latest(
+    add_item(db,
         path       = dira.strpath,
         variable   = 'a',
         mip        = 'b',
         model      = 'c',
         experiment = 'd',
         ensemble   = 'e',
-        version    = 'v01'))
-    db.add(Latest(
+        version    = 'v01')
+    add_item(db,
         path       = dira.strpath,
         variable   = 'a',
         mip        = 'b',
         model      = 'c',
         experiment = 'd',
         ensemble   = 'e',
-        version    = 'v02'))
-    db.add(Latest(
+        version    = 'v02')
+    add_item(db,
         path       = dirb.strpath,
         variable   = 'f',
         mip        = 'g',
         model      = 'c',
         experiment = 'd',
         ensemble   = 'e',
-        version    = 'v01'))
+        version    = 'v01')
     db.commit()
-
-    # Update other tables
-    CMIP5.DB.update(db)
 
     # Close the session
     def fin():

--- a/tests/CMIP5/test_session.py
+++ b/tests/CMIP5/test_session.py
@@ -39,6 +39,7 @@ def test_all(session):
     assert v.count() == 2
 
     assert v[0].variable == u'a'
+    assert len(v[0].versions) == 2
     assert v[0].versions[0].version == u'v01'
     assert v[0].versions[1].version == u'v02'
     


### PR DESCRIPTION
Makes database location configurable with environment variable $CMIP5_DB (will be set by a module on Raijin), fixes #1 
Renames Model.Variable to Model.Instance, following Paola's schema